### PR TITLE
Enhance downloading base64 file such as it works on all major browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "browser-cookies": "^1.2.0",
     "choices.js": "3.0.3",
     "dialog-polyfill": "^0.4.9",
+    "downloadjs": "^1.4.7",
     "dragula": "^3.7.2",
     "eventemitter2": "^5.0.1",
     "flatpickr": "^4.4.6",

--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -1,5 +1,6 @@
 import BaseComponent from '../base/Base';
 import {uniqueName} from '../../utils/utils';
+import download from 'downloadjs';
 
 export default class FileComponent extends BaseComponent {
   static schema(...extend) {
@@ -548,12 +549,7 @@ export default class FileComponent extends BaseComponent {
     fileService.downloadFile(fileInfo).then((file) => {
       if (file) {
         if (file.storage === 'base64') {
-          // this is a workaround to render base64 files in Chrome. Still not working on IE/Edge
-          var hiddenElement = document.createElement('a');
-          hiddenElement.href = 'data:' + file.type + ';base64,' + encodeURI(file.data);
-          hiddenElement.target = '_blank';
-          hiddenElement.download = file.originalName;
-          hiddenElement.click();
+         download(file.url, file.originalName, file.type);
         }
         else {
           window.open(file.url, '_blank');


### PR DESCRIPTION
Enhance downloading base64 file such as it works on all major browser (Chrome, IE, Edge)